### PR TITLE
Removed redundant m64 variable and tweaked uniform distribution test.

### DIFF
--- a/hrw.go
+++ b/hrw.go
@@ -22,14 +22,14 @@ type (
 	}
 )
 
-const m64 = 18446744073709551615 // modulus (2**64-1)
-
 func weight(x uint64, y uint64) uint64 {
 	acc := x ^ y
+	// here used mmh3 64 bit finalizer
+	// https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash3.cpp#L81
 	acc ^= acc >> 33
-	acc = (acc * 0xff51afd7ed558ccd) % m64
+	acc = acc * 0xff51afd7ed558ccd
 	acc ^= acc >> 33
-	acc = (acc * 0xc4ceb9fe1a85ec53) % m64
+	acc = acc * 0xc4ceb9fe1a85ec53
 	acc ^= acc >> 33
 	return acc
 }

--- a/hrw_test.go
+++ b/hrw_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"reflect"
 	"strconv"
 	"testing"
@@ -54,14 +55,14 @@ func (h hashString) Hash() uint64 {
 	hs := fnv.New64()
 	// error always nil
 	_, _ = hs.Write([]byte(h))
-	return (hs.Sum64() >> 1) % m64
+	return hs.Sum64() >> 1
 }
 
 func hash(key []byte) uint64 {
 	h := fnv.New64()
 	// error always nil
 	_, _ = h.Write(key)
-	return (h.Sum64() >> 1) ^ m64
+	return (h.Sum64() >> 1) ^ math.MaxUint64
 }
 
 func mur3hash(key []byte) uint64 {
@@ -184,7 +185,7 @@ func TestSortByWeight(t *testing.T) {
 func TestUniformDistribution(t *testing.T) {
 	var (
 		i      uint64
-		size   = uint64(4)
+		size   = uint64(10)
 		nodes  = make([]uint64, 0, size)
 		counts = make(map[uint64]uint64)
 		key    = make([]byte, 16)
@@ -202,7 +203,7 @@ func TestUniformDistribution(t *testing.T) {
 	}
 
 	mean := float64(keys) / float64(len(nodes))
-	delta := mean * 0.002 // 0.2%
+	delta := mean * 0.01 // 1 %
 	for node, count := range counts {
 		d := mean - float64(count)
 		if d > delta || (0-d) > delta {


### PR DESCRIPTION
I did several changes:

#### Removed m64 constant
```go
const m64 = 18446744073709551615 // modulus (2**64-1)
``` 
There is no point in modulus (uint is unsigned type). 2**64-1 is basically `math.MaxUint64` so it is already defined. 

#### Removed redundant operations
As soon as m64 is `0xFFFF...` there is no point to do `%` operation.
```
X % 0xFF.. = X
```

#### Added description for `weight` function
This function calculates weight with `xor` operation and uses _murmurhash3 uint64 finalizer_ to distribute result. So I put a link to the original code of finalizer. This will explain magic numbers in code. 

#### Tweaked Uniform Distribution Test
Test uses big number of keys (which is good) but on small set of values (which is not so good). Let's use about 10-20 values with less strict verification, because 0.2% is too rough on a big numbers. I think 1% deviation from mean value is sufficient accuracy.